### PR TITLE
Fix typo in Week_01_Quiz.md

### DIFF
--- a/weekly_quiz/Week_01_Quiz.md
+++ b/weekly_quiz/Week_01_Quiz.md
@@ -49,7 +49,7 @@ If you don't see `(base)`, activate the base environment with:
     
 5. Create a new virtual environment using the requirements file:
 
-        (base) $ conda env create -f docs/requirements.yml
+        (base) $ conda env create -f requirements.yml
 
 6. Activate the new environment
 


### PR DESCRIPTION
Hello professor, there seems to be a small typo in the `Week_01_Quiz.md`: `requirements.yml` is not in the `docs` directory.